### PR TITLE
Dont trigger email on empty build and offuscate what we are reading

### DIFF
--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -87,7 +87,7 @@ jobs:
         
         
     - name: Send eBook via email
-      if: ${{ !startsWith(steps.run_omnivook.outputs.last_line, 'ERROR' }}
+      if: ${{ !contains(steps.run_omnivook.outputs.last_line, 'ERROR') }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -106,6 +106,6 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
-      if: ${{ startsWith(steps.run_omnivook.outputs.last_line, 'ERROR' }}
+      if: ${{ contains(steps.run_omnivook.outputs.last_line, 'ERROR') }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -87,7 +87,7 @@ jobs:
         
         
     - name: Send eBook via email
-      if: ${{ !startsWith(steps.run_omnivook.outputs.last_line, "ERROR" }}
+      if: ${{ !startsWith(steps.run_omnivook.outputs.last_line, 'ERROR' }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -106,6 +106,6 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
-      if: ${{ startsWith(steps.run_omnivook.outputs.last_line, "ERROR" }}
+      if: ${{ startsWith(steps.run_omnivook.outputs.last_line, 'ERROR' }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -83,11 +83,13 @@ jobs:
 
         echo "Last line: $last_line"
         # Set the last line as an output
-        echo "::set-output name=last_line::$last_line"
+        echo "last_line=$last_line" >> $GITHUB_OUTPUT
         
         
     - name: Send eBook via email
-      if: ${{ !startsWith(steps.run_omnivook.outputs.last_line, 'ERROR') }}
+      env:
+        OUTPUT_LAST_LINE: ${{ steps.run_omnivook.outputs.last_line }}
+      if: ${{ !contains($OUTPUT_LAST_LINE, 'ERROR') }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -106,8 +108,8 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
-      if: ${{ startsWith(steps.run_omnivook.outputs.last_line, 'ERROR') }}
       env:
         OUTPUT_LAST_LINE: ${{ steps.run_omnivook.outputs.last_line }}
+      if: ${{ contains($OUTPUT_LAST_LINE, 'ERROR') }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -87,7 +87,7 @@ jobs:
         
         
     - name: Send eBook via email
-      if: ${{ !contains(steps.run_omnivook.outputs.last_line, "ERROR" }}
+      if: ${{ !startsWith(steps.run_omnivook.outputs.last_line, "ERROR" }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -106,6 +106,6 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
-      if: ${{ contains(steps.run_omnivook.outputs.last_line, "ERROR" }}
+      if: ${{ startsWith(steps.run_omnivook.outputs.last_line, "ERROR" }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -87,9 +87,7 @@ jobs:
         
         
     - name: Send eBook via email
-      env:
-        OUTPUT_LAST_LINE: ${{ steps.run_omnivook.outputs.last_line }}
-      if: ${{ !contains($OUTPUT_LAST_LINE, 'ERROR') }}
+      if: ${{ !contains(steps.run_omnivook.outputs.last_line }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -108,8 +106,6 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
-      env:
-        OUTPUT_LAST_LINE: ${{ steps.run_omnivook.outputs.last_line }}
-      if: ${{ contains($OUTPUT_LAST_LINE, 'ERROR') }}
+      if: ${{ contains(steps.run_omnivook.outputs.last_line }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -40,6 +40,7 @@ jobs:
         version: "0.4.10"
      
     - name: Generate eBook
+      id: run_omnivook
       env:
         OMNIVORE_TOKEN: ${{ secrets.OMNIVORE_TOKEN }}
         FORCE_COLOR: 1
@@ -75,11 +76,18 @@ jobs:
           EXTRA_FILTER="--filter \"${{ inputs.extra_filter }}\""
         fi
 
-        uv run --with-editable . omnivook --since $SINCE_DATE $LABEL $EXCLUDE_LABEL $ADD_LABEL $EXTRA_FILTER $ARCHIVE_FLAG
+        # Run
+        output=$(uv run --with-editable . omnivook --since $SINCE_DATE $LABEL $EXCLUDE_LABEL $ADD_LABEL $EXTRA_FILTER $ARCHIVE_FLAG)
+        # Capture last line
+        last_line=$(echo "$output" | tail -n 1)
+
+        echo "Last line: $last_line"
+        # Set the last line as an output
+        echo "::set-output name=last_line::$last_line"
         
         
     - name: Send eBook via email
-      if: success() # Only run if previous step succeded
+      if: ${{ !startsWith(steps.run_omnivook.outputs.last_line, 'ERROR') }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -96,3 +104,7 @@ jobs:
         to: ${{ secrets.MAIL_TO }}
         from: ${{ secrets.MAIL_FROM }}
         attachments: "*.epub"
+
+    - name: No eBook send
+      if: ${{ startsWith(steps.run_omnivook.outputs.last_line, 'ERROR') }}
+      run: echo "No saved today or an Error ocurred: ${{ steps.run_omnivook.outputs.last_line }}"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -87,7 +87,7 @@ jobs:
         
         
     - name: Send eBook via email
-      if: ${{ !contains(steps.run_omnivook.outputs.last_line, 'ERROR' }}
+      if: ${{ !contains(steps.run_omnivook.outputs.last_line, "ERROR" }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -106,6 +106,6 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
-      if: ${{ contains(steps.run_omnivook.outputs.last_line, 'ERROR' }}
+      if: ${{ contains(steps.run_omnivook.outputs.last_line, "ERROR" }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -107,4 +107,7 @@ jobs:
 
     - name: No eBook send
       if: ${{ startsWith(steps.run_omnivook.outputs.last_line, 'ERROR') }}
-      run: echo "No saved today or an Error ocurred: ${{ steps.run_omnivook.outputs.last_line }}"
+      env:
+        OUTPUT_LAST_LINE: ${{ steps.run_omnivook.outputs.last_line }}
+      run: |
+        echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -87,7 +87,7 @@ jobs:
         
         
     - name: Send eBook via email
-      if: ${{ !contains(steps.run_omnivook.outputs.last_line }}
+      if: ${{ !contains(steps.run_omnivook.outputs.last_line, 'ERROR' }}
       uses: dawidd6/action-send-mail@v3
       with:
         # setup your mail server connection
@@ -106,6 +106,6 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
-      if: ${{ contains(steps.run_omnivook.outputs.last_line }}
+      if: ${{ contains(steps.run_omnivook.outputs.last_line, 'ERROR' }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"

--- a/.github/workflows/omnivook.yml
+++ b/.github/workflows/omnivook.yml
@@ -106,6 +106,8 @@ jobs:
         attachments: "*.epub"
 
     - name: No eBook send
+      env:
+        OUTPUT_LAST_LINE: ${{steps.run_omnivook.outputs.last_line}}
       if: ${{ contains(steps.run_omnivook.outputs.last_line, 'ERROR') }}
       run: |
         echo "No saved today or an Error ocurred: $OUTPUT_LAST_LINE"


### PR DESCRIPTION
This PR tries to do two things
1. Avoid to show what we are saving in omnivore in the output run
2. Properly set when to send an email
![Captura desde 2024-10-24 18-29-07](https://github.com/user-attachments/assets/029e2783-f54b-4a15-9985-85417f903f7e)
